### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,37 +15,6 @@ $ npm install node-pptx
 ```javascript
 const pptx = require('node-pptx');
 
-// Currently PowerPoint files can only be created by supplying a JSON
-// representation of the presentation to the initializer.
-
-let presentation = new pptx.Presentation({
-  title: 'Hello World',
-  slides: [
-    {elements:
-    [{
-      type: 'Text'
-      attributes: {
-        value: 'Hi!'
-        x: 10,
-        y: 0
-      }
-    },
-    {
-      type: 'Shape',
-      attributes: {
-        type: 'Circle'
-      }
-    },
-    {
-      type: 'Image',
-      attributes: {
-        src: 'http://www.someurl.com/some-image.jpg'
-      }
-    }]}
-  ]
-});
-presentation.save('/tmp/my-presentation');
-
 // In the futures presentations will also be able to composed through the DSL
 new pptx.Presentation()
   .compose(pres => {


### PR DESCRIPTION
It occurred to me this morning that we don’t need to support the JSON object payload in the node-pptx lib itself. This should be done at the microservice level. Then we’ll just iterate over the object and create the pptx as needed. Not adding this logic will keep the lib itself smaller.