### PR TITLE
Added callback wrapper in save().

### DIFF
--- a/lib/presentation.js
+++ b/lib/presentation.js
@@ -156,7 +156,15 @@ class Presentation {
         if (typeof destination === 'string') {
             fs.writeFileSync(destination, await this.createZipBuffer());
         } else if (typeof destination === 'function') {
-            destination(await this.createZipBuffer());
+            // Wrap callback in Promise.resolve() since we don't know if the caller will pass an async or regular callback function.
+            // Plus, since this save() function is async itself, we don't want to lose any exceptions that might be thrown from the
+            // callback (we want them to bubble-up to the caller of save()). Note: in this case, probably could've just simply did:
+            // "return destination(...)" without Promise.resolve() since the return value of "destination()" will either be a promise
+            // anyway (in the case of async), or a value for non-async (including "undefined" if destination returns nothing) which
+            // would be used as the save() function's resolved promise value. So we'd get what we want anyway without the Promise
+            // wrapper, but that relies on the framework to behave exactly as expected and never change in the future - I'd rather
+            // be explicit here rather than implicit.
+            return Promise.resolve(destination(await this.createZipBuffer()));
         } else {
             throw new Error('Invalid destination value in Presentation.save() - can only be a file name or callback function.');
         }


### PR DESCRIPTION
-This ensures that exceptions thrown inside the callback aren't lost if
the callback is async.