### PR TITLE
Add reset font style and text align options

### DIFF
--- a/lib/helpers/ppt-factory-helper.js
+++ b/lib/helpers/ppt-factory-helper.js
@@ -768,6 +768,10 @@ class PptFactoryHelper {
 
             if (options.textAlign) {
                 switch (options.textAlign) {
+                case 'l':
+                case 'left':
+                    alignment = 'l';
+                    break;
                 case 'r':
                 case 'right':
                     alignment = 'r';
@@ -946,7 +950,7 @@ class PptFactoryHelper {
         if(typeof options.rotation === 'number') {
             if(block['a:xfrm'] === undefined) block['a:xfrm'] = [{}];
             if(block['a:xfrm'][0]['$'] === undefined) block['a:xfrm'][0]['$'] = {};
-            
+
             block['a:xfrm'][0]['$'].rot = options.rotation*60000;
         }
     }

--- a/lib/helpers/ppt-factory-helper.js
+++ b/lib/helpers/ppt-factory-helper.js
@@ -738,14 +738,20 @@ class PptFactoryHelper {
 
         if (options.fontBold !== undefined && options.fontBold === true) {
             textRunPropertyBlock['$'].b = '1';
+        } else if (options.fontBold === false) {
+            textRunPropertyBlock['$'].b = '0';
         }
 
         if (options.fontItalic !== undefined && options.fontItalic === true) {
             textRunPropertyBlock['$'].i = '1';
+        } else if (options.fontItalic === false) {
+            textRunPropertyBlock['$'].i = '0';
         }
 
         if (options.fontUnderline !== undefined && options.fontUnderline === true) {
             textRunPropertyBlock['$'].u = 'sng';
+        } else if (options.fontUnderline === false) {
+            delete textRunPropertyBlock['$'].u;
         }
 
         if (options.fontSubscript !== undefined && options.fontSubscript === true) {


### PR DESCRIPTION
Sometimes when modifying an existing presentation, it has some built-in font styles, which i want to override explicitly.
For examle, I have some presentation and I want to add a text box using slide.addText(). When I see the result, the added text is bold and centered, so I want to set fontBold: false and textAlign: 'left' to get proper style.