### PR TITLE
DPI Override in ElementProperties > PptxUnitHelper

### DIFF
--- a/lib/element-properties.js
+++ b/lib/element-properties.js
@@ -6,6 +6,7 @@ class ElementProperties {
         this._y = 0;
         this._cx = 0;
         this._cy = 0;
+        this._dpi = 72;
         this.options = {};
     }
 
@@ -16,12 +17,13 @@ class ElementProperties {
         this.y(this._y);
         this.cx(this._cx);
         this.cy(this._cy);
+        this.dpi(this._dpi);
     }
 
     x(val) {
         if (arguments.length === 0) {
             if (this.properties !== undefined) {
-                return PptxUnitHelper.toPixels(this.properties['a:off'][0]['$'].x);
+                return PptxUnitHelper.toPixels(this.properties['a:off'][0]['$'].x, this.properties['a:off'][0]['$'].dpi);
             } else {
                 return this._x;
             }
@@ -29,7 +31,7 @@ class ElementProperties {
             this._x = val;
 
             if (this.properties !== undefined) {
-                this.properties['a:off'][0]['$'].x = PptxUnitHelper.fromPixels(val);
+                this.properties['a:off'][0]['$'].x = PptxUnitHelper.fromPixels(val, this._dpi);
             }
         }
 
@@ -39,7 +41,7 @@ class ElementProperties {
     y(val) {
         if (arguments.length === 0) {
             if (this.properties !== undefined) {
-                return PptxUnitHelper.toPixels(this.properties['a:off'][0]['$'].y);
+                return PptxUnitHelper.toPixels(this.properties['a:off'][0]['$'].y, this.properties['a:off'][0]['$'].dpi);
             } else {
                 return this._y;
             }
@@ -47,7 +49,7 @@ class ElementProperties {
             this._y = val;
 
             if (this.properties !== undefined) {
-                this.properties['a:off'][0]['$'].y = PptxUnitHelper.fromPixels(val);
+                this.properties['a:off'][0]['$'].y = PptxUnitHelper.fromPixels(val, this._dpi);
             }
         }
 
@@ -57,7 +59,7 @@ class ElementProperties {
     cx(val) {
         if (arguments.length === 0) {
             if (this.properties !== undefined) {
-                return PptxUnitHelper.toPixels(this.properties['a:ext'][0]['$'].cx);
+                return PptxUnitHelper.toPixels(this.properties['a:ext'][0]['$'].cx, this.properties['a:off'][0]['$'].dpi);
             } else {
                 return this._cx;
             }
@@ -65,7 +67,7 @@ class ElementProperties {
             this._cx = val;
 
             if (this.properties !== undefined) {
-                this.properties['a:ext'][0]['$'].cx = PptxUnitHelper.fromPixels(val);
+                this.properties['a:ext'][0]['$'].cx = PptxUnitHelper.fromPixels(val, this._dpi);
             }
         }
 
@@ -75,7 +77,7 @@ class ElementProperties {
     cy(val) {
         if (arguments.length === 0) {
             if (this.properties !== undefined) {
-                return PptxUnitHelper.toPixels(this.properties['a:ext'][0]['$'].cy);
+                return PptxUnitHelper.toPixels(this.properties['a:ext'][0]['$'].cy, this._dpi);
             } else {
                 return this._cy;
             }
@@ -83,7 +85,21 @@ class ElementProperties {
             this._cy = val;
 
             if (this.properties !== undefined) {
-                this.properties['a:ext'][0]['$'].cy = PptxUnitHelper.fromPixels(val);
+                this.properties['a:ext'][0]['$'].cy = PptxUnitHelper.fromPixels(val, this._dpi);
+            }
+        }
+
+        return this;
+    }
+
+    dpi(val) {
+        if (arguments.length === 0) {
+            return this._dpi;
+        } else {
+            this._dpi = val;
+
+            if (this.properties !== undefined) {
+                this.properties['a:off'][0]['$'].dpi = val;
             }
         }
 

--- a/lib/element-properties.js
+++ b/lib/element-properties.js
@@ -77,7 +77,7 @@ class ElementProperties {
     cy(val) {
         if (arguments.length === 0) {
             if (this.properties !== undefined) {
-                return PptxUnitHelper.toPixels(this.properties['a:ext'][0]['$'].cy, this._dpi);
+                return PptxUnitHelper.toPixels(this.properties['a:ext'][0]['$'].cy, this.properties['a:off'][0]['$'].dpi);
             } else {
                 return this._cy;
             }

--- a/lib/helpers/unit-helper.js
+++ b/lib/helpers/unit-helper.js
@@ -4,24 +4,24 @@ class PptxUnitHelper {
         return Math.floor(val * 914400);
     }
 
-    static fromPoints(val) {
-        return Math.floor(val * 914400 / 72);
+    static fromPoints(val, dpi = 72) {
+        return Math.floor(val * 914400 / dpi);
     }
 
-    static fromPixels(val) {
-        return Math.floor(val * 914400 / 72);
+    static fromPixels(val, dpi = 72) {
+        return Math.floor(val * 914400 / dpi);
     }
 
-    static toPixels(val) {
-        return val * 72 / 914400;
+    static toPixels(val, dpi = 72) {
+        return val * dpi / 914400;
     }
 
     static toInches(val) {
         return val / 914400;
     }
 
-    static toPoints(val) {
-        return val / 914400 * 72;
+    static toPoints(val, dpi = 72) {
+        return val / 914400 * dpi;
     }
 
     static fromCm(val) {


### PR DESCRIPTION
### Simple override of default 72 DPI used in PptxUnitHelper.

**Solves**
Adding images into our PowerPoint template results in dimension overrides, in the form of scaling.
Our template is set at 96 DPI, resulting in a scaling of 133% of all inserted images, using the default DPI of 72.
This allows us to specifically set the targeted DPI when adding images, thus eliminating the scaling altogether.

**Notes**
This may be required for some other elements as well, shapes and textboxes, but I've left those alone, as we're not using them.
This was the easiest way to achieve our needs of not having to switch to a different library.

In a perfect world, the DPI settings should be read from the document, and automatically be used in calculations. But I do not have the required experience with PowerPoint, to actually achieve this.