### PR TITLE
Fixed crash when using shrinkText on textElements

### DIFF
--- a/lib/helpers/ppt-factory-helper.js
+++ b/lib/helpers/ppt-factory-helper.js
@@ -901,7 +901,7 @@ class PptFactoryHelper {
         let internalLeftRightMargin = PptxUnitHelper.toPoints(PptxUnitHelper.fromInches(0.1)) * 2; // default internal margin is 0.10 inches on both sides
         let textAreaWidthPoints = PptxUnitHelper.toPoints(PptxUnitHelper.fromPixels(shapeObject.cx())) - internalLeftRightMargin; // the width of the _drawable_ text area in a shape
 
-        if (shapeObject.shapeType.name === 'chevron') {
+        if (shapeObject.shapeType !== undefined && shapeObject.shapeType.name === 'chevron') {
             // since a chevron is a non-rectangle weird shape, PowerPoint doesn't allow a text line to go all the way to the right edge before breaking into a new line;
             // seems to be padding of about 20% on the right side, so we decrease the drawable text area width by this amount
             textAreaWidthPoints *= 0.8;


### PR DESCRIPTION
Hey Mark, I made a one-line bug in node-pptx that I'll need merged into master for a demo on Monday. The bug was simply that if you used the shrinkText property on a textElement (as opposed to a shapeElement object, where it's more commonly used), node-pptx would crash. It was crashing on that one line that assumes shapeElement is defined; it won't be if you're a textElement object instead, so I just check if the shapeElement object is not undefined in that if() statement I modified.

Please review and merge.

Thanks!!